### PR TITLE
Update Toyota C-HR generations: Added Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Toyota C-HR
+
+This repository contains signal set configurations for the Toyota C-HR, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Toyota C-HR.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Toyota_C-HR"
+
 generations:
   - name: "First Generation"
     start_year: 2016


### PR DESCRIPTION
- Added references array with Toyota C-HR Wikipedia URL
- Updated README.md with standard template
- Verified generational data against Wikipedia article (First Gen: 2016-2023, Second Gen: 2023-present)
